### PR TITLE
description formatted correctly, tests now have commas and will run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,11 +8,11 @@ License: What license is it under?
 Encoding: UTF-8
 LazyData: true
 Imports: ggplot2,
-         caret
-         glmnet
-         dplyr
-         glue
-         rpart
+         caret,
+         glmnet,
+         dplyr,
+         glue,
+         rpart,
          mlbench
 Suggests: testthat,
     knitr,

--- a/tests/testthat/test_score.R
+++ b/tests/testthat/test_score.R
@@ -2,12 +2,12 @@ library(dplyr)
 library(caret)
 library(ezmodelR)
 
-test_that("score() returns a function" {
+test_that("score() returns a function", {
   expect_type(score("rf", "mse"), "closure")
 })
 
 
-test_that("score() using mse returns a double"{
+test_that("score() using mse returns a double", {
   is_setosa <- function(x){
     if(x == "setosa"){
       return(1)
@@ -24,7 +24,7 @@ test_that("score() using mse returns a double"{
 })
 
 
-test_that("score() using MSE on a random forest is working correctly"{
+test_that("score() using MSE on a random forest is working correctly", {
   # This covers case A in the score function
   is_setosa <- function(x){
     if(x == "setosa"){
@@ -45,7 +45,7 @@ test_that("score() using MSE on a random forest is working correctly"{
   expect_equal(score("rf","mse")(x,y), sum(((as.numeric(y_pred) - 1) - y)^2))
 })
 
-test_that("score() correctly returns an error when an unsupported score_type is passed"{
+test_that("score() correctly returns an error when an unsupported score_type is passed", {
   # This covers case B in the score function
   expect_error(score('rf', 'banana'))
 

--- a/tests/testthat/test_train_test_plot.R
+++ b/tests/testthat/test_train_test_plot.R
@@ -60,28 +60,28 @@ test_that("Passing model, score_type, and hyperparameter leads to correct plot",
 
 #Test B
 
-test_that("random_seed is numeric" {
+test_that("random_seed is numeric", {
   expect_warning(test_train_plot(model = "decision_tree" , score_type = "accuracy", x = Sonar[,1:60],
                                  y = Sonar[,61], hyperparameter = "cp",param_range = seq(0,1,.05), random_seed= NA), "random_seed needs to be numeric.")
 })
 
 
 #Test C
-test_that("Function returns error when unexpected model is specified" {
+test_that("Function returns error when unexpected model is specified", {
   expect_warning(test_train_plot(model = "ridge" , score_type = "accuracy", x = Sonar[,1:60],
                                  y = Sonar[,61], hyperparameter = "cp", random_seed= 123), "'lasso', 'ridge', and 'logistic' regression are not implemented yet. Please, choose model = 'decision tree'")
 })
 
 
 #Test D
-test_that("Function returns error when unexpected score is specified" {
+test_that("Function returns error when unexpected score is specified", {
   expect_warning(test_train_plot(model = "decision_tree" , score_type = NA, x = Sonar[,1:60],
                                  y = Sonar[,61], hyperparameter = "cp",param_range = seq(0,1,.05), random_seed= 123), "score_type for decision_tree needs to be 'accuracy'")
 })
 
 
 #Test E
-test_that("Function returns error when unexpected hyperparameter is specified" {
+test_that("Function returns error when unexpected hyperparameter is specified", {
   expect_warning(test_train_plot(model = "decision_tree" , score_type = "accuracy", x = Sonar[,1:60],
                                  y = Sonar[,61], hyperparameter = NA,param_range = seq(0,1,.05), random_seed= 123), "The hyperparameter for a decision_tree has to be 'cp'")
 })


### PR DESCRIPTION
Tests were missing `,`, so they run now. Added commas between required packages in `DESCRIPTION`